### PR TITLE
added api keys and middleware

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,4 @@
 NODE_ENV=development
 PORT=5001
 MONGODB_URL='mongodb://localhost/psgc'
+API_SECRET=''

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "psgc_backend",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -979,6 +979,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "nanoid": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -1339,6 +1344,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "shortid": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
+      "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
+      "requires": {
+        "nanoid": "^2.1.0"
+      }
     },
     "sift": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "express-rate-limit": "^5.2.3",
     "helmet": "^4.2.0",
     "mongoose": "^5.10.15",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "shortid": "^2.2.16"
   },
   "devDependencies": {
     "nodemon": "^2.0.6"

--- a/src/api/keys.js
+++ b/src/api/keys.js
@@ -1,0 +1,21 @@
+const shortid = require('shortid');
+const ApiKey = require('../models/apiKeys');
+const handleAsync = require('../utils/handleAsync');
+const encryptKey = require('../utils/encryptKey');
+
+/**
+ * !PATH: /key
+ */
+const getApiKey = handleAsync(async (req, res, next) => {
+
+    const randomKey = shortid.generate();
+
+    const randomKeyEncrypted = encryptKey(randomKey)
+
+    await ApiKey.create({ key: randomKeyEncrypted });
+
+    res.json({ key: randomKey });
+
+})
+
+module.exports = { getApiKey };

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const middlewares = require('./middlewares');
 
 /* api */
 const api = require('./api/_index');
+const apiKeyController = require('./api/keys');
 
 require('dotenv').config();
 
@@ -35,13 +36,16 @@ app.set('trust proxy', 1);
 /* routes */
 app.use(express.static('public'));
 
-// /* limiter for all routes */
+/* limiter for all routes */
 app.use(limiter)
 
-/* api */
-app.use('/api', api);
+/* generate api key */
+app.use('/key', apiKeyController.getApiKey)
 
-// /* errorHandler middlerware */
+/* api with apikey check */
+app.use('/api', middlewares.checkApiKey, api);
+
+/* errorHandler middlerware */
 app.use(middlewares.notFound);
 app.use(middlewares.errorHandler);
 

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -1,10 +1,14 @@
-const notFound = (req,res,next) => {
+const ApiKey = require('./models/apiKeys');
+const encryptKey = require('./utils/encryptKey');
+const handleAsync = require('./utils/handleAsync');
+
+const notFound = (req, res, next) => {
     const error = new Error(`Not found - ${req.originalUrl}`);
     res.status(404);
-    next(error); 
+    next(error);
 }
 
-const errorHandler = (error,req,res,next) => {
+const errorHandler = (error, req, res, next) => {
     const statusCode = res.statusCode === 200 ? 500 : res.statusCode;
     res.status(statusCode);
     res.json({
@@ -13,7 +17,22 @@ const errorHandler = (error,req,res,next) => {
     });
 }
 
+const checkApiKey = handleAsync(async (req, res, next) => {
+    const { key } = req.query;
+
+    if (!key) throw new Error('Please provide a valid API key')
+
+    const encryptedKeyQuery = encryptKey(key);
+
+    const [foundKey] = await ApiKey.find({ key: encryptedKeyQuery })
+
+    if (!foundKey) throw new Error('Please provide a valid API key')
+
+    next()
+})
+
 module.exports = {
     notFound,
     errorHandler,
+    checkApiKey
 }

--- a/src/models/apiKeys.js
+++ b/src/models/apiKeys.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+const { Schema } = mongoose;
+
+const psgcApiKeys = new Schema({
+    key: {
+        type: String,
+        required: true
+    }
+}, {
+    timestamps: true
+});
+
+const ApiKey = mongoose.model('ApiKey', psgcApiKeys, 'psgc_keys');
+
+module.exports = ApiKey;

--- a/src/utils/encryptKey.js
+++ b/src/utils/encryptKey.js
@@ -1,0 +1,9 @@
+const crypto = require('crypto');
+
+const encryptKey = text => {
+    return crypto.createHmac('sha256', process.env.API_SECRET)
+        .update(text)
+        .digest('hex');
+}
+
+module.exports = encryptKey;


### PR DESCRIPTION
for the api key requirement support

API keys can be generated by making a GET request on "/key" route,
-- api keys now required (via a middleware) for all routes except for the /key route.

API keys are stored in the database (in their hashed version, for security ) to be used if a user needs to access a route

to use the API key, append it as a query string
-- eg: /api/region?&key=Api_key_value

if API key is not defined/incorrect, it will return an HTTP 500 status code with error message "Please provide a valid API key"
-- can be modified in the middlwares.js

NOTE: all the routes were tested with the api key generated by the /key route and returns an error when not provided or if the api key is incorrect/not existing in the database